### PR TITLE
Meilleur healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
     ports:
     - 5434:5432
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s
       retries: 5
 


### PR DESCRIPTION
changement de `pg_isready -U postgres` en `pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}` puisqu'on utilise des custom, plus de logs d'erreur sur le container database